### PR TITLE
libdf: Introduce ordering index for dataloading.

### DIFF
--- a/libDF/Cargo.toml
+++ b/libDF/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 default = []
 
 transforms = ["thiserror", "ndarray"]
-dataset = ["thiserror", "ndarray", "hdf5", "rand", "rand_xoshiro", "rayon", "serde_json", "serde", "lewton", "ogg", "hound", "rubato", "bincode"]
+dataset = ["thiserror", "ndarray", "hdf5", "rand", "rand_xoshiro", "rayon", "crossbeam-channel", "serde_json", "serde", "lewton", "ogg", "hound", "rubato", "bincode"]
 
 [dependencies]
 rustfft = "^6.0.1"
@@ -30,6 +30,7 @@ hdf5 = { version="^0.8", optional=true }
 bincode = { version="^1.3", optional=true }
 ndarray = { version="^0.15", optional=true, features=["serde"] }
 rayon = { version="1.5", optional=true }
+crossbeam-channel = { version="^0.5", optional=true }
 serde_json = { version="1.0", optional=true }
 serde = { version = "1.0", features = ["derive"], optional=true }
 lewton = { version = "^0.10", optional=true }

--- a/pyDF-data/libdfdata/torch_dataloader.py
+++ b/pyDF-data/libdfdata/torch_dataloader.py
@@ -76,6 +76,7 @@ class PytorchDataLoader:
         prefetch=4,
         num_workers=None,
         pin_memory=True,
+        drop_last=False,  # Drop the last batch if it contains fewer samples then batch_size
         fft_dataloader=False,  # Following parameters are only used if fft_dataloader == True
         fft_size: int = None,  # FFT size for stft calcualtion
         hop_size: int = None,  # Hop size for stft calcualtion
@@ -112,6 +113,7 @@ class PytorchDataLoader:
                 p_atten_lim=p_atten_lim,
                 p_reverb=p_reverb,
                 prefetch=prefetch_loader,
+                drop_last=drop_last,
                 overfit=overfit,
                 seed=seed,
                 min_nb_erb_freqs=min_nb_erb_freqs,
@@ -128,6 +130,7 @@ class PytorchDataLoader:
                 p_atten_lim=p_atten_lim,
                 p_reverb=p_reverb,
                 prefetch=prefetch_loader,
+                drop_last=drop_last,
                 overfit=overfit,
                 seed=seed,
                 min_nb_erb_freqs=min_nb_erb_freqs,
@@ -178,6 +181,10 @@ class PytorchDataLoader:
 
     def len(self, split: str) -> int:
         return self.loader.len_of(split)
+
+    def __len__(self) -> int:
+        """Return training length."""
+        return self.len("train")
 
     def dataset_len(self, split: str) -> int:
         return self.loader.dataset_len(split)

--- a/pyDF-data/src/lib.rs
+++ b/pyDF-data/src/lib.rs
@@ -81,6 +81,7 @@ impl _TdDataLoader {
         prefetch: Option<usize>,
         p_atten_lim: Option<f32>,
         p_reverb: Option<f32>,
+        drop_last: Option<bool>,
         overfit: Option<bool>,
         seed: Option<u64>,
         min_nb_erb_freqs: Option<usize>,
@@ -118,6 +119,9 @@ impl _TdDataLoader {
         }
         if let Some(bs_eval) = batch_size_eval {
             builder = builder.batch_size_eval(bs_eval);
+        }
+        if let Some(drop_last) = drop_last {
+            builder = builder.drop_last(drop_last);
         }
         if let Some(overfit) = overfit {
             builder = builder.overfit(overfit);
@@ -196,6 +200,7 @@ impl _FdDataLoader {
         prefetch: Option<usize>,
         p_atten_lim: Option<f32>,
         p_reverb: Option<f32>,
+        drop_last: Option<bool>,
         overfit: Option<bool>,
         seed: Option<u64>,
         min_nb_erb_freqs: Option<usize>,
@@ -241,6 +246,9 @@ impl _FdDataLoader {
         }
         if let Some(bs_eval) = batch_size_eval {
             dl_builder = dl_builder.batch_size_eval(bs_eval);
+        }
+        if let Some(drop_last) = drop_last {
+            dl_builder = dl_builder.drop_last(drop_last);
         }
         if let Some(overfit) = overfit {
             dl_builder = dl_builder.overfit(overfit);


### PR DESCRIPTION
This ensures the same order of sample independent on batch size and
number of workers.

Handle seeding in get_sample by providing current epoch seed.

Fixes #42