### PR TITLE
fix: Link to licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ If you use the DeepFilterNet2 model, please cite: *DeepFilterNet2: Towards Real-
 
 DeepFilterNet is free and open source! All code in this repository is dual-licensed under either:
 
-* MIT License ([LICENSE-MIT](docs/LICENSE-MIT) or [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT))
-* Apache License, Version 2.0 ([LICENSE-APACHE](docs/LICENSE-APACHE) or [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0))
+* MIT License ([LICENSE-MIT](LICENSE-MIT) or [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT))
+* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0))
 
 at your option. This means you can select the license you prefer!
 


### PR DESCRIPTION
The links to `LICENSE-MIT` and `LICENSE-APACHE` in `README.md` were pointing to `docs/LICENSE-MIT` and `docs/LICENSE-APACHE` respectively, which were non-existent. Have modified the links to the right location.