### PR TITLE
Set sr as keyword argument in load_audio

### DIFF
--- a/DeepFilterNet/df/io.py
+++ b/DeepFilterNet/df/io.py
@@ -13,7 +13,7 @@ from df.utils import download_file, get_cache_dir, get_git_root
 
 
 def load_audio(
-    file: str, sr: Optional[int], verbose=True, **kwargs
+    file: str, sr: Optional[int] = None, verbose=True, **kwargs
 ) -> Tuple[Tensor, AudioMetaData]:
     """Loads an audio file using torchaudio.
 


### PR DESCRIPTION
The [`load_audio`](https://github.com/Rikorose/DeepFilterNet/blob/main/DeepFilterNet/df/io.py#L15) function suggests that the sample rate `sr` argument should be optional with a default value of `None`. However, it's not set as a keyword argument with a default value. This, very minor, PR fixes this by making `sr` a keyword argument.