### PR TITLE
Allow deep-filter-py version output without additional parameters

### DIFF
--- a/.github/workflows/test_df.yml
+++ b/.github/workflows/test_df.yml
@@ -128,6 +128,7 @@ jobs:
           DNS_AUTH_KEY: ${{ secrets.DNS_AUTH_KEY }}
         run: |
           mkdir ../out
+          poetry run deepFilter --version
           poetry run deepFilter ../assets/noisy_snr0.wav -o ../out
           poetry run python df/scripts/dnsmos.py ../assets/noisy_snr0.wav -t 4.320409320319172 2.53722799232174 3.209282577524924
           poetry run python df/scripts/dnsmos.py ../out/noisy_snr0_DeepFilterNet2.wav -t 4.12677460716050 4.45606916030286 3.62059268038164

--- a/DeepFilterNet/df/enhance.py
+++ b/DeepFilterNet/df/enhance.py
@@ -240,6 +240,15 @@ def parse_epoch_type(value: str) -> Union[int, str]:
         return value
 
 
+class PrintVersion(argparse.Action):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, *args):
+        print("DeepFilterNet", __version__)
+        exit(0)
+
+
 def setup_df_argument_parser(default_log_level: str = "INFO") -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -277,7 +286,7 @@ def setup_df_argument_parser(default_log_level: str = "INFO") -> argparse.Argume
         type=parse_epoch_type,
         help="Epoch for checkpoint loading. Can be one of ['best', 'latest', <int>].",
     )
-    parser.add_argument("--version", action="store_true")
+    parser.add_argument("--version", action=PrintVersion, nargs="?")
     return parser
 
 
@@ -309,9 +318,6 @@ def run():
         help="Don't add the model suffix to the enhanced audio files",
     )
     args = parser.parse_args()
-    if args.version:
-        print("DeepFilterNet", __version__)
-        exit(0)
     main(args)
 
 

--- a/DeepFilterNet/df/enhance.py
+++ b/DeepFilterNet/df/enhance.py
@@ -247,7 +247,7 @@ class PrintVersion(argparse.Action):
             dest=dest,
             nargs=0,
             required=False,
-            help="Print DeepFilterNet version information"
+            help="Print DeepFilterNet version information",
         )
 
     def __call__(self, *args):

--- a/DeepFilterNet/df/enhance.py
+++ b/DeepFilterNet/df/enhance.py
@@ -241,8 +241,14 @@ def parse_epoch_type(value: str) -> Union[int, str]:
 
 
 class PrintVersion(argparse.Action):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, option_strings, dest):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=0,
+            required=False,
+            help="Print DeepFilterNet version information"
+        )
 
     def __call__(self, *args):
         print("DeepFilterNet", __version__)
@@ -286,7 +292,7 @@ def setup_df_argument_parser(default_log_level: str = "INFO") -> argparse.Argume
         type=parse_epoch_type,
         help="Epoch for checkpoint loading. Can be one of ['best', 'latest', <int>].",
     )
-    parser.add_argument("--version", action=PrintVersion, nargs="?")
+    parser.add_argument("-v", "--version", action=PrintVersion)
     return parser
 
 


### PR DESCRIPTION
Currently, if you want to output the DeepFilterNet version via the command line script `deep-filter-py` you need to run:

```bash
deep-filter-py --version path_to_wavfile
```

i.e., you also need to give it at least one positional argument even though the code just exits after printing the version.

This PR is a minor "fix" that allows the version to be output without an additional positional argument.