### PR TITLE
pyproject.toml: update from poetry to poetry-core

### DIFF
--- a/DeepFilterNet/pyproject.toml
+++ b/DeepFilterNet/pyproject.toml
@@ -55,8 +55,8 @@ install-torch-cuda11 = "python -m pip install torch==1.12.0 torchaudio==0.12.0 -
 install-torch-cpu = "python -m pip install torch==1.12.0 torchaudio==0.12.0 --extra-index-url https://download.pytorch.org/whl/cpu/"
 
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 100

--- a/scripts/WAcc.py
+++ b/scripts/WAcc.py
@@ -32,7 +32,7 @@ def main(args):
             with open(fpath, "rb") as f:
                 resp = requests.post(WACC_SERVICE_URL, files={"audiodata": f})
             wacc = resp.json()
-        except:
+        except:  # noqa: E722
             print("Error occured during scoring")
             print("response is ", resp)
         sf.write(fpath, original_audio, fs)

--- a/scripts/WAcc_mean.py
+++ b/scripts/WAcc_mean.py
@@ -1,7 +1,7 @@
 #!/bin/env/python
 
-import sys
 import os
+import sys
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
As stated [here](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517), the `build-system` in `pyproject.toml` should be updated from using `poetry` to `poetry-core`. I'm not sure what will happen in the future if this doesn't get changed (maybe there'll be some deprecation `poetry`), but it seems a harmless change.