### PR TITLE
Call data_queue.task_done() after data_queue.get() to prevent blockin…

### DIFF
--- a/pyDF-data/libdfdata/torch_dataloader.py
+++ b/pyDF-data/libdfdata/torch_dataloader.py
@@ -159,16 +159,12 @@ class PytorchDataLoader:
                 while True:
                     try:  # Empty queue
                         _ = self.data_queue.get(timeout=2)
+                        if hasattr(self.data_queue, "task_done"):
+                            # self.data_queue.get() without a subsequent task_done()
+                            # will cause self.data_queue.join() to wait indefinitely.
+                            self.data_queue.task_done()
                     except queue.Empty:
                         break
-                if hasattr(self.data_queue, "task_done"):
-                    while True:
-                        # self.data_queue.get() without a subsequent task_done()
-                        # will cause self.data_queue.join() to wait indefinitely.
-                        try:
-                            self.data_queue.task_done()
-                        except ValueError:
-                            break
 
                 self.pin_memory_thread.join()
                 self.data_queue.join()


### PR DESCRIPTION
Fixes #236. Attempting to join a queue without draining the known tasks will cause the caller to block. 