### PR TITLE
Use version.parse to compare torch versions

### DIFF
--- a/pyDF-data/libdfdata/torch_dataloader.py
+++ b/pyDF-data/libdfdata/torch_dataloader.py
@@ -4,15 +4,15 @@ import queue
 import threading
 import time
 import warnings
-from packaging import version
 from typing import Iterator, List, Optional, Tuple
 
 import numpy as np
 import torch
 from loguru import logger
+
 from torch._utils import ExceptionWrapper
 from torch.utils.data._utils.pin_memory import _pin_memory_loop
-
+from packaging import version
 from libdfdata import _FdDataLoader
 
 

--- a/pyDF-data/libdfdata/torch_dataloader.py
+++ b/pyDF-data/libdfdata/torch_dataloader.py
@@ -4,6 +4,7 @@ import queue
 import threading
 import time
 import warnings
+from packaging import version
 from typing import Iterator, List, Optional, Tuple
 
 import numpy as np
@@ -177,7 +178,7 @@ class PytorchDataLoader:
                 torch.cuda.current_device(),
                 self.pin_memory_thread_done_event,
             )
-            if torch.__version__ >= "1.12.0":
+            if version.parse(torch.__version__) >= version.parse("1.12.0"):
                 args = args + (None,)
             pin_memory_thread = threading.Thread(
                 target=_pin_memory_loop,

--- a/pyDF-data/libdfdata/torch_dataloader.py
+++ b/pyDF-data/libdfdata/torch_dataloader.py
@@ -9,10 +9,10 @@ from typing import Iterator, List, Optional, Tuple
 import numpy as np
 import torch
 from loguru import logger
-
+from packaging import version
 from torch._utils import ExceptionWrapper
 from torch.utils.data._utils.pin_memory import _pin_memory_loop
-from packaging import version
+
 from libdfdata import _FdDataLoader
 
 


### PR DESCRIPTION
Currently, in `torch_dataloader.py`, there is a check that if the PyTorch version is `>= "1.12.0"`, it adds an additional required argument for the `_pin_memory_loop` function. However, this check does not work as expected, so even for PyTorch versions below 1.12.0 the additional argument gets added and this breaks training. For example, if I have a PyTorch version "1.9.0+cu111", then:

```python
"1.9.0+cu111" >= "1.12.0"
```

evaluates as `True`

This PR uses the [`version.parse`](https://packaging.pypa.io/en/stable/version.html#packaging.version.parse) function in the `packaging` module to [compare the version numbers](https://stackoverflow.com/a/11887885/1862861), which correctly gives the expected output, e.g, 

```python
from packaging import version
version.parse("1.9.0+cu111") >= version.parse("1.12.0")
```

evaluates as `False`. 
