### PR TITLE
Update PyTorch version requirement in README to v1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This framework supports Linux, MacOS and Windows. Training is only tested under 
 
 Install the DeepFilterNet Python wheel via pip:
 ```bash
-# Install cpu/cuda pytorch (>=1.8) dependency from pytorch.org, e.g.:
+# Install cpu/cuda pytorch (>=1.9) dependency from pytorch.org, e.g.:
 pip install torch torchaudio -f https://download.pytorch.org/whl/cpu/torch_stable.html
 # Install DeepFilterNet
 pip install deepfilternet


### PR DESCRIPTION
If using PyTorch v1.8, the training fails with the error:

```
TypeError: clip_grad_norm_() got an unexpected keyword argument 'error_if_nonfinite'
```

It seems that the `error_if_nonfinite` keyword for the PyTorch `clip_grad_norm_` function wasn't introduced until v1.9. This PR just updates the `README.md` file to say to use versions >=1.9 rather than >=1.8 (this is easier than putting a version check in the code and passing different arguments in each case).