### PR TITLE
Allow JIT compiled deepfiltermodel3 to work in training

### DIFF
--- a/DeepFilterNet/df/deepfilternet3.py
+++ b/DeepFilterNet/df/deepfilternet3.py
@@ -242,7 +242,14 @@ class ErbDecoder(nn.Module):
             p.conv_ch, 1, kernel_size=p.conv_kernel, activation_layer=nn.Sigmoid
         )
 
-    def forward(self, emb, e3, e2, e1, e0) -> Tensor:
+    def forward(
+        self,
+        emb: Tensor,
+        e3: Tensor,
+        e2: Tensor,
+        e1: Tensor,
+        e0: Tensor
+    ) -> Tensor:
         # Estimates erb mask
         b, _, t, f8 = e3.shape
         emb, _ = self.emb_gru(emb)

--- a/DeepFilterNet/df/deepfilternet3.py
+++ b/DeepFilterNet/df/deepfilternet3.py
@@ -242,14 +242,7 @@ class ErbDecoder(nn.Module):
             p.conv_ch, 1, kernel_size=p.conv_kernel, activation_layer=nn.Sigmoid
         )
 
-    def forward(
-        self,
-        emb: Tensor,
-        e3: Tensor,
-        e2: Tensor,
-        e1: Tensor,
-        e0: Tensor
-    ) -> Tensor:
+    def forward(self, emb: Tensor, e3: Tensor, e2: Tensor, e1: Tensor, e0: Tensor) -> Tensor:
         # Estimates erb mask
         b, _, t, f8 = e3.shape
         emb, _ = self.emb_gru(emb)

--- a/DeepFilterNet/df/modules.py
+++ b/DeepFilterNet/df/modules.py
@@ -690,7 +690,7 @@ class SqueezedGRU(nn.Module):
         else:
             self.linear_out = nn.Identity()
 
-    def forward(self, input: Tensor, h=None) -> Tuple[Tensor, Tensor]:
+    def forward(self, input: Tensor, h: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
         input = self.linear_in(input)
         x, h = self.gru(input, h)
         if self.gru_skip is not None:
@@ -729,7 +729,7 @@ class SqueezedGRU_S(nn.Module):
         else:
             self.linear_out = nn.Identity()
 
-    def forward(self, input: Tensor, h=None) -> Tuple[Tensor, Tensor]:
+    def forward(self, input: Tensor, h: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
         x = self.linear_in(input)
         x, h = self.gru(x, h)
         x = self.linear_out(x)

--- a/DeepFilterNet/df/multiframe.py
+++ b/DeepFilterNet/df/multiframe.py
@@ -170,7 +170,7 @@ class DF(MultiFrameModule):
         spec_u = self.spec_unfold(torch.view_as_complex(spec))
         coefs = torch.view_as_complex(coefs)
         spec_f = spec_u.narrow(-2, 0, self.num_freqs)
-        coefs = coefs.view(coefs.shape[0], -1, self.frame_size, *coefs.shape[2:])
+        coefs = coefs.view(coefs.shape[0], -1, self.frame_size, coefs.shape[2], coefs.shape[3])
         if self.conj:
             coefs = coefs.conj()
         spec_f = df(spec_f, coefs)


### PR DESCRIPTION
When I try turning on JIT compilation of the deepfilternet3 model during training it fails to compile the model. This seems to be due to two things:

* the `forward` method in `SqueezedGRU` and `SqueezedGRU_S` does not explicitly type hint the `h` argument with `Optional[Tensor]`;
* when setting the `coefs.view` in the `DF` class in multiframe.py it need the dimensions to all be explicit rather than trying to work them out from the expansion of `*coefs.shape[2:]`.

This PR fixes both of these things.

The change in multiframe.py does assume that the `coefs` tensor always has 4 dimension, so if that's not the case then a slight change will be required.