### PR TITLE
Fix wrong channel in Pipewire mono source example

### DIFF
--- a/ladspa/filter-chain-configs/deepfilter-mono-source.conf
+++ b/ladspa/filter-chain-configs/deepfilter-mono-source.conf
@@ -41,7 +41,7 @@ context.modules = [
                 ]
             }
             audio.rate = 48000
-            audio.position = [FL]
+            audio.position = [MONO]
             capture.props = {
                 node.passive = true
             }


### PR DESCRIPTION
The Pipewire example for creating a noise-suppressing virtual microphone sets the only channel as FL (front-left), which makes audio from the microphone present only on the left channel. Setting the channel to MONO instead fixes the issue.