### PR TITLE
[feat] allow specifying compute device

### DIFF
--- a/DeepFilterNet/df/utils.py
+++ b/DeepFilterNet/df/utils.py
@@ -17,13 +17,19 @@ from df.config import config
 from df.model import ModelParams
 
 
-def get_device():
-    s = config("DEVICE", default="", section="train")
-    if s == "":
+def get_device(device: Optional[str] = None):
+    s = device or config("DEVICE", default="", section="train")
+    if not s:
         if torch.cuda.is_available():
-            DEVICE = torch.device("cuda:0")
-        else:
+            DEVICE = torch.device("cuda")
+        elif torch.mps.is_available():
+            DEVICE = torch.device("mps")
+        elif torch.xpu.is_available():
+            DEVICE = torch.device("xpu")
+        elif torch.cpu.is_available():
             DEVICE = torch.device("cpu")
+        else:
+            raise RuntimeError("No compute devices found")
     else:
         DEVICE = torch.device(s)
     return DEVICE


### PR DESCRIPTION
This PR allows a user to specify the torch compute device in addition to automatically selecting one. It adds additional devices which will be automatically selected if available.

I had run into an issue where I needed to run the program on an `mps` device, and I wasn't able to do so with the current device selection.