### PR TITLE
fix documentation in enhance.py (DeepFilterNet3 vs DeepFilterNet2 as default)

### DIFF
--- a/DeepFilterNet/df/enhance.py
+++ b/DeepFilterNet/df/enhance.py
@@ -112,7 +112,7 @@ def init_df(
 
     Args:
         model_base_dir (str): Path to the model directory containing checkpoint and config. If None,
-            load the pretrained DeepFilterNet2 model.
+            load the pretrained DeepFilterNet3 model.
         post_filter (bool): Enable post filter for some minor, extra noise reduction.
         log_level (str): Control amount of logging. Defaults to `INFO`.
         log_file (str): Optional log file name. None disables it. Defaults to `enhance.log`.
@@ -254,7 +254,7 @@ def maybe_download_model(name: str = DEFAULT_MODEL) -> str:
     """Download a DeepFilterNet model.
 
     Args:
-        - name (str): Model name. Currently needs to one of `[DeepFilterNet, DeepFilterNet2]`.
+        - name (str): Model name. Currently needs to one of `[DeepFilterNet, DeepFilterNet2, DeepFilterNet3]`.
 
     Returns:
         - base_dir: Return the model base directory as string.
@@ -308,7 +308,7 @@ def setup_df_argument_parser(
         default=None,
         help="Model directory containing checkpoints and config. "
         "To load a pretrained model, you may just provide the model name, e.g. `DeepFilterNet`. "
-        "By default, the pretrained DeepFilterNet2 model is loaded.",
+        "By default, the pretrained DeepFilterNet3 model is loaded.",
     )
     parser.add_argument(
         "--pf",


### PR DESCRIPTION
fix documentation: DeepFilterNet3 is loaded by default, not DeepFilterNet2 (as stated in the comments)