### PR TITLE
[checkpoint.py] Set torch.load weights_only to False explicitly

### DIFF
--- a/DeepFilterNet/df/checkpoint.py
+++ b/DeepFilterNet/df/checkpoint.py
@@ -74,7 +74,7 @@ def read_cp(
         epoch = get_epoch(latest)
     if log:
         logger.info("Found checkpoint {} with epoch {}".format(latest, epoch))
-    latest = torch.load(latest, map_location="cpu")
+    latest = torch.load(latest, map_location="cpu", weights_only=False)
     latest = {k.replace("clc", "df"): v for k, v in latest.items()}
     if blacklist:
         reg = re.compile("".join(f"({b})|" for b in blacklist)[:-1])


### PR DESCRIPTION
Hello,
As it is stated here
<img width="1599" height="114" alt="default_weights_only_true" src="https://github.com/user-attachments/assets/bf5989bb-a20a-43b2-8865-2e64ee6214e4" />
the default value has been changed in PyTorch 2.6 so that training process fails when we resume it
