### PR TITLE
Fix: handle CUDA tensors in df_features() by moving audio to CPU before NumPy conversion 

### DIFF
--- a/DeepFilterNet/df/enhance.py
+++ b/DeepFilterNet/df/enhance.py
@@ -188,7 +188,7 @@ def init_df(
 
 
 def df_features(audio: Tensor, df: DF, nb_df: int, device=None) -> Tuple[Tensor, Tensor, Tensor]:
-    spec = df.analysis(audio.numpy())  # [C, Tf] -> [C, Tf, F]
+    spec = df.analysis(audio.detach().cpu().numpy()) # [C, Tf] -> [C, Tf, F]
     a = get_norm_alpha(False)
     erb_fb = df.erb_widths()
     with warnings.catch_warnings():


### PR DESCRIPTION
While working on a personal project using **DeepFilterNet** with an external model operating on CUDA tensors, I encountered the following error:
```shell
spec = df.analysis(audio.numpy())  # [C, Tf] -> [C, Tf, F]
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
^C
```
To resolve this, I applied **.detach()** and **.cpu()** on the audio tensor to remove it from autograd graph and move to the  CPU.
```python
spec = df.analysis(audio.detach().cpu().numpy())
```