### PR TITLE
Fix crash when git is not installed in container

### DIFF
--- a/DeepFilterNet/df/utils.py
+++ b/DeepFilterNet/df/utils.py
@@ -142,7 +142,7 @@ def get_git_root():
         git_local_dir = os.path.dirname(os.path.abspath(__file__))
         args = ["git", "-C", git_local_dir, "rev-parse", "--show-toplevel"]
         return subprocess.check_output(args).strip().decode()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return None
 
 
@@ -154,7 +154,7 @@ def get_commit_hash():
             return None
         args = ["git", "-C", git_dir, "rev-parse", "--short", "--verify", "HEAD"]
         return subprocess.check_output(args).strip().decode()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         # probably not in git repo
         return None
 
@@ -168,7 +168,7 @@ def get_branch_name():
         git_dir = os.path.dirname(os.path.abspath(__file__))
         args = ["git", "-C", git_dir, "rev-parse", "--abbrev-ref", "HEAD"]
         branch = subprocess.check_output(args).strip().decode()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         # probably not in git repo
         branch = None
     return branch


### PR DESCRIPTION
Catch FileNotFoundError in addition to CalledProcessError in git utility functions. When git binary is missing (e.g., in minimal containers), subprocess.check_output raises FileNotFoundError instead of CalledProcessError, causing the application to crash.

Modified functions:
- get_git_root()
- get_commit_hash()
- get_branch_name()