### PR TITLE
build(deps): enable rustfft `wasm_simd` feature

### DIFF
--- a/libDF/Cargo.toml
+++ b/libDF/Cargo.toml
@@ -94,7 +94,11 @@ wasm = [
 hdf5-static = ["hdf5?/static"]
 
 [dependencies]
-rustfft = "^6.1.0"
+# `wasm_simd` is a no-op on non-wasm targets (cfg-gated inside rustfft), so
+# enabling it unconditionally is safe for the cdylib/staticlib/native bin
+# matrix. On `wasm32-unknown-unknown` with `+simd128` it lets rustfft's
+# `FftPlannerWasmSimd` use v128 butterflies instead of scalar fallback.
+rustfft = { version = "^6.1.0", features = ["wasm_simd"] }
 realfft = "^3.1.0"
 itertools = "0.12"
 num-complex = { version = "^0.4", features = ["serde"] }


### PR DESCRIPTION
## Summary

Adds the `wasm_simd` feature to the `rustfft` dependency in `libDF/Cargo.toml`.

## Why

`wasm_simd` is `cfg`-gated inside rustfft to `target_arch = "wasm32"` + the feature flag, so enabling it unconditionally is a no-op on every non-wasm target — safe for the cdylib / staticlib / native bin matrix. Native builds are byte-identical.

On `wasm32-unknown-unknown` with `+simd128`, this lets rustfft's auto-planner pick `FftPlannerWasmSimd` (v128 butterflies) instead of falling back to the scalar planner.

## Caveats

- DFN3's specific FFT sizes (480 / 960 mixed-radix) don't materially benefit — tested same-machine back-to-back, RTF stayed at 0.066 on Chromium within noise. The relative share of FFT work in DFN3's per-frame budget is small enough that the speedup gets washed out.
- Other downstream rustfft consumers (apps with larger or power-of-2 FFT sizes) should benefit more.
- Wasm size cost is real: the codegen adds ~400 KB compressed.

Opening this anyway because it's bit-exact, zero-risk, and a sensible default for the wasm path. Happy to gate it behind a libDF feature flag (e.g. `wasm-simd-fft`) instead if you prefer it opt-in.

## Test plan

- [x] Native `cargo check --features tract,default-model` clean.
- [x] Wasm32 build with `wasm-pack build --target web --release --features wasm` succeeds.
- [x] FNV-1a hash of `df_process_frame` output bit-equal to baseline across Chromium / WebKit / Firefox.